### PR TITLE
Fix up plugin descriptor dependencies

### DIFF
--- a/modules/aggregations/src/main/java/org/elasticsearch/aggregations/AggregationsPlugin.java
+++ b/modules/aggregations/src/main/java/org/elasticsearch/aggregations/AggregationsPlugin.java
@@ -16,6 +16,7 @@ import org.elasticsearch.aggregations.bucket.histogram.AutoDateHistogramAggregat
 import org.elasticsearch.aggregations.bucket.histogram.InternalAutoDateHistogram;
 import org.elasticsearch.aggregations.pipeline.MovFnPipelineAggregationBuilder;
 import org.elasticsearch.aggregations.pipeline.MovingFunctionScript;
+import org.elasticsearch.plugins.ExtensiblePlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.ScriptPlugin;
 import org.elasticsearch.plugins.SearchPlugin;
@@ -23,7 +24,7 @@ import org.elasticsearch.script.ScriptContext;
 
 import java.util.List;
 
-public class AggregationsPlugin extends Plugin implements SearchPlugin, ScriptPlugin {
+public class AggregationsPlugin extends Plugin implements ExtensiblePlugin, SearchPlugin, ScriptPlugin {
     @Override
     public List<AggregationSpec> getAggregations() {
         return List.of(

--- a/x-pack/plugin/autoscaling/build.gradle
+++ b/x-pack/plugin/autoscaling/build.gradle
@@ -12,6 +12,7 @@ esplugin {
 archivesBaseName = 'x-pack-autoscaling'
 
 dependencies {
+  compileOnly project(':modules:aggregations')
   compileOnly project(path: xpackModule('core'))
   testImplementation(testArtifact(project(xpackModule('core'))))
   testImplementation project(':modules:data-streams')

--- a/x-pack/plugin/core/build.gradle
+++ b/x-pack/plugin/core/build.gradle
@@ -19,6 +19,7 @@ esplugin {
   classname 'org.elasticsearch.xpack.core.XPackPlugin'
   hasNativeController false
   requiresKeystore false
+  extendedPlugins = ['aggregations']
 }
 
 tasks.named("dependencyLicenses").configure {
@@ -28,7 +29,7 @@ tasks.named("dependencyLicenses").configure {
 
 dependencies {
   compileOnly project(":server")
-  api project(":modules:aggregations")
+  compileOnly project(":modules:aggregations")
   api project(':libs:elasticsearch-grok')
   api project(":libs:elasticsearch-ssl-config")
   api "org.apache.httpcomponents:httpclient:${versions.httpclient}"

--- a/x-pack/plugin/eql/build.gradle
+++ b/x-pack/plugin/eql/build.gradle
@@ -5,7 +5,7 @@ esplugin {
   name 'x-pack-eql'
   description 'The Elasticsearch plugin that powers EQL for Elasticsearch'
   classname 'org.elasticsearch.xpack.eql.plugin.EqlPlugin'
-  extendedPlugins = ['x-pack-ql', 'lang-painless']
+  extendedPlugins = ['x-pack-ql']
 }
 
 ext {

--- a/x-pack/plugin/mapper-constant-keyword/build.gradle
+++ b/x-pack/plugin/mapper-constant-keyword/build.gradle
@@ -7,7 +7,7 @@ esplugin {
   name 'constant-keyword'
   description 'Module for the constant-keyword field type, which is a specialization of keyword for the case when all documents have the same value.'
   classname 'org.elasticsearch.xpack.constantkeyword.ConstantKeywordMapperPlugin'
-  extendedPlugins = ['x-pack-core', 'lang-painless']
+  extendedPlugins = ['x-pack-core']
 }
 archivesBaseName = 'x-pack-constant-keyword'
 

--- a/x-pack/plugin/mapper-unsigned-long/build.gradle
+++ b/x-pack/plugin/mapper-unsigned-long/build.gradle
@@ -18,7 +18,7 @@ esplugin {
   name 'unsigned-long'
   description 'Module for the unsigned long field type'
   classname 'org.elasticsearch.xpack.unsignedlong.UnsignedLongMapperPlugin'
-  extendedPlugins = ['x-pack-core', 'lang-painless']
+  extendedPlugins = ['x-pack-core']
 }
 archivesBaseName = 'x-pack-unsigned-long'
 

--- a/x-pack/plugin/mapper-version/build.gradle
+++ b/x-pack/plugin/mapper-version/build.gradle
@@ -12,7 +12,7 @@ esplugin {
   name 'mapper-version'
   description 'A plugin for a field type to store software versions'
   classname 'org.elasticsearch.xpack.versionfield.VersionFieldPlugin'
-  extendedPlugins = ['x-pack-core', 'lang-painless']
+  extendedPlugins = ['x-pack-core']
 }
 archivesBaseName = 'x-pack-mapper-version'
 

--- a/x-pack/plugin/ml/build.gradle
+++ b/x-pack/plugin/ml/build.gradle
@@ -9,7 +9,7 @@ esplugin {
   description 'Elasticsearch Expanded Pack Plugin - Machine Learning'
   classname 'org.elasticsearch.xpack.ml.MachineLearning'
   hasNativeController true
-  extendedPlugins = ['x-pack-autoscaling', 'lang-painless']
+  extendedPlugins = ['x-pack-autoscaling']
 }
 
 def localRepo = providers.systemProperty('build.ml_cpp.repo').orNull
@@ -70,6 +70,7 @@ esplugin.bundleSpec.exclude 'platform/licenses/**'
 
 dependencies {
   compileOnly project(':modules:lang-painless:spi')
+  compileOnly project(':modules:aggregations')
   compileOnly project(path: xpackModule('core'))
   compileOnly project(path: xpackModule('autoscaling'))
   testImplementation(testArtifact(project(xpackModule('core'))))

--- a/x-pack/plugin/ql/build.gradle
+++ b/x-pack/plugin/ql/build.gradle
@@ -17,6 +17,7 @@ archivesBaseName = 'x-pack-ql'
 dependencies {
   api "org.antlr:antlr4-runtime:${antlrVersion}"
   api project(path: xpackModule('mapper-version'))
+  compileOnly project(':modules:aggregations')
   compileOnly project(path: xpackModule('core'))
   testApi(project(xpackModule('ql:test-fixtures'))) {
     exclude group: 'org.elasticsearch.plugin', module: 'ql'

--- a/x-pack/plugin/rollup/build.gradle
+++ b/x-pack/plugin/rollup/build.gradle
@@ -9,6 +9,7 @@ esplugin {
 archivesBaseName = 'x-pack-rollup'
 
 dependencies {
+  compileOnly project(':modules:aggregations')
   compileOnly project(path: xpackModule('core'))
   compileOnly project(':modules:data-streams')
   compileOnly project(path: xpackModule('ilm'))

--- a/x-pack/plugin/spatial/build.gradle
+++ b/x-pack/plugin/spatial/build.gradle
@@ -7,7 +7,7 @@ esplugin {
   name 'spatial'
   description 'A plugin for Basic Spatial features'
   classname 'org.elasticsearch.xpack.spatial.SpatialPlugin'
-  extendedPlugins = ['x-pack-core', 'legacy-geo', 'lang-painless']
+  extendedPlugins = ['x-pack-core', 'legacy-geo']
 }
 
 dependencies {

--- a/x-pack/plugin/sql/build.gradle
+++ b/x-pack/plugin/sql/build.gradle
@@ -7,7 +7,7 @@ esplugin {
   name 'x-pack-sql'
   description 'The Elasticsearch plugin that powers SQL for Elasticsearch'
   classname 'org.elasticsearch.xpack.sql.plugin.SqlPlugin'
-  extendedPlugins = ['x-pack-ql', 'lang-painless']
+  extendedPlugins = ['x-pack-ql']
 }
 
 ext {
@@ -29,6 +29,7 @@ configurations {
 archivesBaseName = 'x-pack-sql'
 
 dependencies {
+  compileOnly project(':modules:aggregations')
   compileOnly project(path: xpackModule('core'))
   compileOnly(project(':modules:lang-painless:spi'))
   api project('sql-action')

--- a/x-pack/plugin/transform/build.gradle
+++ b/x-pack/plugin/transform/build.gradle
@@ -9,6 +9,7 @@ esplugin {
 
 dependencies {
   compileOnly project(":server")
+  compileOnly project(':modules:aggregations')
   compileOnly project(path: xpackModule('core'))
 
   testImplementation(testArtifact(project(xpackModule('core'))))

--- a/x-pack/plugin/watcher/build.gradle
+++ b/x-pack/plugin/watcher/build.gradle
@@ -6,7 +6,7 @@ esplugin {
   classname 'org.elasticsearch.xpack.watcher.Watcher'
   hasNativeController false
   requiresKeystore false
-  extendedPlugins = ['x-pack-core', 'lang-painless']
+  extendedPlugins = ['x-pack-core']
 }
 
 archivesBaseName = 'x-pack-watcher'

--- a/x-pack/plugin/wildcard/build.gradle
+++ b/x-pack/plugin/wildcard/build.gradle
@@ -7,12 +7,13 @@ esplugin {
   name 'wildcard'
   description 'A plugin for a keyword field type with efficient wildcard search'
   classname 'org.elasticsearch.xpack.wildcard.Wildcard'
-  extendedPlugins = ['x-pack-core', 'lang-painless']
+  extendedPlugins = ['x-pack-core']
 }
 archivesBaseName = 'x-pack-wildcard'
 
 dependencies {
   compileOnly project(':modules:lang-painless:spi')
+  compileOnly project(':modules:aggregations')
   compileOnly project(path: xpackModule('core'))
   testImplementation(testArtifact(project(xpackModule('core'))))
 }


### PR DESCRIPTION
With the move of a the composite aggs code to the aggregations plugin, this effectively renders the aggregation plugin as an Extensible plugin ( since x-pack-core uses the composite aggs code directly ). The X-pack-core plugin then requires to "extend" the aggregation plugin, so that the classloader hierarchy is setup correctly at runtime.   Following all this, lang-painless is now transitively required (by the aggregations plugin ), for all plugins extending x-pack-core, so we need to move it as an explicit "extends" from plugins that extend from x-pack-core